### PR TITLE
fix: remediate MetaSponse Flashpoint findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2023-2025 Splunk Inc.
+   Copyright (c) 2023-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Metasponse
-Copyright (c) 2023-2025 Splunk Inc.
+Copyright (c) 2023-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/actions/metasponse_create_job.py
+++ b/actions/metasponse_create_job.py
@@ -1,6 +1,6 @@
 # File: metasponse_create_job.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/actions/metasponse_get_all_jobs.py
+++ b/actions/metasponse_get_all_jobs.py
@@ -1,6 +1,6 @@
 # File: metasponse_get_all_jobs.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/actions/metasponse_get_job_status.py
+++ b/actions/metasponse_get_job_status.py
@@ -1,6 +1,6 @@
 # File: metasponse_get_job_status.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,9 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-import phantom.app as phantom
 from urllib.parse import quote
+
+import phantom.app as phantom
 
 import metasponse_consts as consts
 from actions import BaseAction

--- a/actions/metasponse_get_job_status.py
+++ b/actions/metasponse_get_job_status.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import phantom.app as phantom
+from urllib.parse import quote
 
 import metasponse_consts as consts
 from actions import BaseAction
@@ -25,7 +26,7 @@ class JobStatus(BaseAction):
     def execute(self):
         """Execute get job status action."""
 
-        job_name = self._param["job_name"]
+        job_name = quote(str(self._param["job_name"]), safe="")
         params = {"allow_stale": True}
 
         endpoint = consts.METASPONSE_PICK_UP_JOB_GET_JOB_STATUS.format(job_name=job_name)

--- a/actions/metasponse_job_control.py
+++ b/actions/metasponse_job_control.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import phantom.app as phantom
+from urllib.parse import quote
 
 import metasponse_consts as consts
 from actions import BaseAction
@@ -25,7 +26,7 @@ class JobControl(BaseAction):
     def execute(self):
         """Execute job control action."""
 
-        job_name = self._param["job_name"]
+        job_name = quote(str(self._param["job_name"]), safe="")
         action = self._param.get("action")
 
         if action not in ["pickup", "abort"]:

--- a/actions/metasponse_job_control.py
+++ b/actions/metasponse_job_control.py
@@ -1,6 +1,6 @@
 # File: metasponse_job_control.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,9 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-import phantom.app as phantom
 from urllib.parse import quote
+
+import phantom.app as phantom
 
 import metasponse_consts as consts
 from actions import BaseAction

--- a/actions/metasponse_kill_job.py
+++ b/actions/metasponse_kill_job.py
@@ -1,6 +1,6 @@
 # File: metasponse_kill_job.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,9 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-import phantom.app as phantom
 from urllib.parse import quote
+
+import phantom.app as phantom
 
 import metasponse_consts as consts
 from actions import BaseAction

--- a/actions/metasponse_kill_job.py
+++ b/actions/metasponse_kill_job.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import phantom.app as phantom
+from urllib.parse import quote
 
 import metasponse_consts as consts
 from actions import BaseAction
@@ -25,7 +26,7 @@ class KillJob(BaseAction):
     def execute(self):
         """Execute kill job action."""
 
-        job_name = self._param["job_name"]
+        job_name = quote(str(self._param["job_name"]), safe="")
 
         endpoint = consts.METASPONSE_KILL_JOB.format(job_name=job_name)
 

--- a/actions/metasponse_list_plugins.py
+++ b/actions/metasponse_list_plugins.py
@@ -1,6 +1,6 @@
 # File: metasponse_list_plugins.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/actions/metasponse_run_job.py
+++ b/actions/metasponse_run_job.py
@@ -1,6 +1,6 @@
 # File: metasponse_run_job.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,9 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-import phantom.app as phantom
 from urllib.parse import quote
+
+import phantom.app as phantom
 
 import metasponse_consts as consts
 from actions import BaseAction

--- a/actions/metasponse_run_job.py
+++ b/actions/metasponse_run_job.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import phantom.app as phantom
+from urllib.parse import quote
 
 import metasponse_consts as consts
 from actions import BaseAction
@@ -25,7 +26,7 @@ class RunJob(BaseAction):
     def execute(self):
         """Execute run job action."""
 
-        builder_id = self._param["builder_id"]
+        builder_id = quote(str(self._param["builder_id"]), safe="")
         delta = self._param.get("delta")
         template = self._param.get("template", False)
         body = {"template": template}

--- a/actions/metasponse_test_connectivity.py
+++ b/actions/metasponse_test_connectivity.py
@@ -1,6 +1,6 @@
 # File: metasponse_test_connectivity.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metasponse.json
+++ b/metasponse.json
@@ -31,6 +31,7 @@
         "verify_server_cert": {
             "description": "Verify server certificate",
             "data_type": "boolean",
+            "default": true,
             "order": 1
         }
     },

--- a/metasponse.json
+++ b/metasponse.json
@@ -10,7 +10,7 @@
     "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2023-2025 Splunk Inc.",
+    "license": "Copyright (c) 2023-2026 Splunk Inc.",
     "app_version": "1.0.3",
     "utctime_updated": "2025-09-05T19:08:07.035175Z",
     "package_name": "phantom_metasponse",

--- a/metasponse_connector.py
+++ b/metasponse_connector.py
@@ -1,6 +1,6 @@
 # File: metasponse_connector.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metasponse_consts.py
+++ b/metasponse_consts.py
@@ -1,6 +1,6 @@
 # File: metasponse_consts.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metasponse_utils.py
+++ b/metasponse_utils.py
@@ -130,6 +130,11 @@ class MetasponseUtils:
 
         # Please specify the status codes here
         if 200 <= r.status_code < 399:
+            if isinstance(resp_json, dict):
+                api_error = resp_json.get("error") or resp_json.get("validation_errors")
+                if api_error:
+                    action_result.add_data(resp_json)
+                    return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error from server: {api_error}"), None)
             return RetVal(phantom.APP_SUCCESS, resp_json)
 
         # You should process the error returned in the json

--- a/metasponse_utils.py
+++ b/metasponse_utils.py
@@ -1,6 +1,6 @@
 # File: metasponse_utils.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metasponse_utils.py
+++ b/metasponse_utils.py
@@ -186,7 +186,7 @@ class MetasponseUtils:
 
         try:
             r = request_func(
-                url, timeout=consts.METASPONSE_REQUEST_DEFAULT_TIMEOUT, verify=self._connector.config.get("verify_server_cert", False), **kwargs
+                url, timeout=consts.METASPONSE_REQUEST_DEFAULT_TIMEOUT, verify=self._connector.config.get("verify_server_cert", True), **kwargs
             )
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e!s}"), resp_json)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * URL-encoded job names and builder IDs before inserting them into API paths.
 * Preserved API errors returned inside successful HTTP responses.
+* Enabled TLS certificate verification by default.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * URL-encoded job names and builder IDs before inserting them into API paths.
+* Preserved API errors returned inside successful HTTP responses.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* URL-encoded job names and builder IDs before inserting them into API paths.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/metasponse_config.py
+++ b/tests/metasponse_config.py
@@ -1,6 +1,6 @@
 # File: metasponse_config.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_create_job.py
+++ b/tests/test_metasponse_create_job.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_create_job.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_get_all_jobs.py
+++ b/tests/test_metasponse_get_all_jobs.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_get_all_jobs.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_get_job_status.py
+++ b/tests/test_metasponse_get_job_status.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_get_job_status.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_job_control.py
+++ b/tests/test_metasponse_job_control.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_job_control.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_kill_job.py
+++ b/tests/test_metasponse_kill_job.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_kill_job.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_list_plugins.py
+++ b/tests/test_metasponse_list_plugins.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_list_plugins.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_run_job.py
+++ b/tests/test_metasponse_run_job.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_run_job.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_test_connectivity.py
+++ b/tests/test_metasponse_test_connectivity.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_test_connectivity.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_metasponse_utils.py
+++ b/tests/test_metasponse_utils.py
@@ -1,6 +1,6 @@
 # File: test_metasponse_utils.py
 #
-# Copyright (c) 2023-2025 Splunk Inc.
+# Copyright (c) 2023-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- encode job names and builder IDs used in API paths
- propagate API errors returned inside successful HTTP responses
- enable TLS certificate verification by default
- refresh generated artifacts with current shared tooling

## Tracking

- [PAPP-38239](https://splunk.atlassian.net/browse/PAPP-38239)
- [PSAAS-31352](https://splunk.atlassian.net/browse/PSAAS-31352)
- [PSAAS-31794](https://splunk.atlassian.net/browse/PSAAS-31794)
- [PSAAS-32273](https://splunk.atlassian.net/browse/PSAAS-32273)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Validation

- `pre-commit run --all-files`
- Python compile validation

Written by Codex.