### PR TITLE
fix: reject dot-segment job identifiers [Codex]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.43.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/actions/metasponse_get_job_status.py
+++ b/actions/metasponse_get_job_status.py
@@ -13,8 +13,6 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from urllib.parse import quote
-
 import phantom.app as phantom
 
 import metasponse_consts as consts
@@ -27,7 +25,10 @@ class JobStatus(BaseAction):
     def execute(self):
         """Execute get job status action."""
 
-        job_name = quote(str(self._param["job_name"]), safe="")
+        ret_val, job_name = self._connector.util.validate_path_segment(self._action_result, self._param["job_name"], "job_name")
+        if phantom.is_fail(ret_val):
+            return self._action_result.get_status()
+
         params = {"allow_stale": True}
 
         endpoint = consts.METASPONSE_PICK_UP_JOB_GET_JOB_STATUS.format(job_name=job_name)

--- a/actions/metasponse_job_control.py
+++ b/actions/metasponse_job_control.py
@@ -13,8 +13,6 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from urllib.parse import quote
-
 import phantom.app as phantom
 
 import metasponse_consts as consts
@@ -27,7 +25,10 @@ class JobControl(BaseAction):
     def execute(self):
         """Execute job control action."""
 
-        job_name = quote(str(self._param["job_name"]), safe="")
+        ret_val, job_name = self._connector.util.validate_path_segment(self._action_result, self._param["job_name"], "job_name")
+        if phantom.is_fail(ret_val):
+            return self._action_result.get_status()
+
         action = self._param.get("action")
 
         if action not in ["pickup", "abort"]:

--- a/actions/metasponse_kill_job.py
+++ b/actions/metasponse_kill_job.py
@@ -13,8 +13,6 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from urllib.parse import quote
-
 import phantom.app as phantom
 
 import metasponse_consts as consts
@@ -27,7 +25,9 @@ class KillJob(BaseAction):
     def execute(self):
         """Execute kill job action."""
 
-        job_name = quote(str(self._param["job_name"]), safe="")
+        ret_val, job_name = self._connector.util.validate_path_segment(self._action_result, self._param["job_name"], "job_name")
+        if phantom.is_fail(ret_val):
+            return self._action_result.get_status()
 
         endpoint = consts.METASPONSE_KILL_JOB.format(job_name=job_name)
 

--- a/actions/metasponse_run_job.py
+++ b/actions/metasponse_run_job.py
@@ -13,8 +13,6 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from urllib.parse import quote
-
 import phantom.app as phantom
 
 import metasponse_consts as consts
@@ -27,7 +25,10 @@ class RunJob(BaseAction):
     def execute(self):
         """Execute run job action."""
 
-        builder_id = quote(str(self._param["builder_id"]), safe="")
+        ret_val, builder_id = self._connector.util.validate_path_segment(self._action_result, self._param["builder_id"], "builder_id")
+        if phantom.is_fail(ret_val):
+            return self._action_result.get_status()
+
         delta = self._param.get("delta")
         template = self._param.get("template", False)
         body = {"template": template}

--- a/metasponse_utils.py
+++ b/metasponse_utils.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import json
+from urllib.parse import quote
 
 import phantom.app as phantom
 import requests
@@ -58,6 +59,14 @@ class MetasponseUtils:
             return action_result.set_status(phantom.APP_ERROR, consts.METASPONSE_ERROR_ZERO_INT_PARAM.format(key=key)), None
 
         return phantom.APP_SUCCESS, parameter
+
+    def validate_path_segment(self, action_result, parameter, key):
+        """Reject traversal-only identifiers and encode accepted path segments."""
+        parameter = str(parameter)
+        if parameter in {".", ".."}:
+            return action_result.set_status(phantom.APP_ERROR, consts.METASPONSE_ERROR_INVALID_ACTION_PARAM.format(key=key)), None
+
+        return phantom.APP_SUCCESS, quote(parameter, safe="")
 
     def _get_error_message_from_exception(self, e):
         """Get an appropriate error message from the exception.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Reject exact dot-segment job and builder identifiers before constructing API endpoints.

--- a/tests/test_metasponse_get_job_status.py
+++ b/tests/test_metasponse_get_job_status.py
@@ -90,3 +90,12 @@ class GetJobStatusAction(unittest.TestCase):
             params={"allow_stale": True},
             headers={},
         )
+
+    def test_get_job_status_rejects_dot_segments(self, mock_get):
+        for job_name in (".", ".."):
+            with self.subTest(job_name=job_name):
+                self.test_json["parameters"] = [{"job_name": job_name}]
+                ret_val = json.loads(self.connector._handle_action(json.dumps(self.test_json), None))
+                self.assertEqual(ret_val["status"], "failed")
+
+        mock_get.assert_not_called()

--- a/tests/test_metasponse_job_control.py
+++ b/tests/test_metasponse_job_control.py
@@ -135,3 +135,12 @@ class JobControlAction(unittest.TestCase):
             data={"action": "pickup"},
             headers={},
         )
+
+    def test_job_control_rejects_dot_segments(self, mock_post):
+        for job_name in (".", ".."):
+            with self.subTest(job_name=job_name):
+                self.test_json["parameters"] = [{"job_name": job_name, "action": "pickup"}]
+                ret_val = json.loads(self.connector._handle_action(json.dumps(self.test_json), None))
+                self.assertEqual(ret_val["status"], "failed")
+
+        mock_post.assert_not_called()

--- a/tests/test_metasponse_kill_job.py
+++ b/tests/test_metasponse_kill_job.py
@@ -81,3 +81,12 @@ class GetJobStatusAction(unittest.TestCase):
         mock_delete.assert_called_with(
             f"{self.test_json['config']['base_url']}{endpoint}", timeout=consts.METASPONSE_REQUEST_DEFAULT_TIMEOUT, verify=False, headers={}
         )
+
+    def test_kill_job_rejects_dot_segments(self, mock_delete):
+        for job_name in (".", ".."):
+            with self.subTest(job_name=job_name):
+                self.test_json["parameters"] = [{"job_name": job_name}]
+                ret_val = json.loads(self.connector._handle_action(json.dumps(self.test_json), None))
+                self.assertEqual(ret_val["status"], "failed")
+
+        mock_delete.assert_not_called()

--- a/tests/test_metasponse_run_job.py
+++ b/tests/test_metasponse_run_job.py
@@ -63,6 +63,15 @@ class RunJobAction(unittest.TestCase):
             headers={},
         )
 
+    def test_run_job_rejects_dot_segments(self, mock_post):
+        for builder_id in (".", ".."):
+            with self.subTest(builder_id=builder_id):
+                self.test_json["parameters"] = [{"builder_id": builder_id, "template": False}]
+                ret_val = json.loads(self.connector._handle_action(json.dumps(self.test_json), None))
+                self.assertEqual(ret_val["status"], "failed")
+
+        mock_post.assert_not_called()
+
     def test_run_job_with_delta_valid(self, mock_post):
         """
         Test the valid case for the run job action.


### PR DESCRIPTION
## Summary

- centralize validation and encoding of job and builder path segments
- reject exact `.` and `..` identifiers before all four reported endpoint requests
- add action-level regressions proving rejected values never reach the HTTP client
- refresh connector quality-tool revisions in a separate maintenance commit

## Tracking

- [PAPP-38239](https://splunk.atlassian.net/browse/PAPP-38239)
- [PSAAS-31352](https://splunk.atlassian.net/browse/PSAAS-31352)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)
- Provenance: VULN-94077

## Validation

- Python compilation of all changed source and test modules
- `pre-commit run --all-files`
- local pytest was unavailable because this clone does not provide the SOAR `phantom` test runtime; hosted pytest is required

Merge strategy: merge commit only; do not squash.

Written by Codex.
